### PR TITLE
fix peer dependency resolution by republishing

### DIFF
--- a/demo-plugin/package-lock.json
+++ b/demo-plugin/package-lock.json
@@ -11,9 +11,9 @@
         "@types/react-dom": "18.2.4",
         "eslint": "8.41.0",
         "eslint-config-next": "13.4.3",
-        "ethersjs-nomo-plugins": "^0.0.2",
+        "ethersjs-nomo-plugins": "^0.1.1",
         "next": "13.4.3",
-        "nomo-plugin-kit": "^0.0.6",
+        "nomo-plugin-kit": "^0.1.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "typescript": "5.0.4"
@@ -2173,16 +2173,16 @@
       }
     },
     "node_modules/ethersjs-nomo-plugins": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/ethersjs-nomo-plugins/-/ethersjs-nomo-plugins-0.0.2.tgz",
-      "integrity": "sha512-PUqS6eIrwTPwXcsHOEFYuwycxIO9kzhsoZfIu7NDvx896NFGv7cXdo26ap7N+csR1oBe8PsuBRZVK5Bp5EjF0A==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ethersjs-nomo-plugins/-/ethersjs-nomo-plugins-0.1.1.tgz",
+      "integrity": "sha512-noG65aaLssNKBjWrgGVgm7dMz10rNZAwS5eDcBO+RKQhmlcpPluP6obbgnn22KXRrvTuxRQ0xEQdekzilC0/Sw==",
       "dependencies": {
         "@types/node": "^20.5.9",
         "ethers": "^5.7.2",
         "typescript": "5.0.4"
       },
       "peerDependencies": {
-        "nomo-plugin-kit": "^0.0.5"
+        "nomo-plugin-kit": "^0.1.0"
       }
     },
     "node_modules/ethersjs-nomo-plugins/node_modules/@types/node": {
@@ -3201,9 +3201,9 @@
       }
     },
     "node_modules/nomo-plugin-kit": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/nomo-plugin-kit/-/nomo-plugin-kit-0.0.6.tgz",
-      "integrity": "sha512-NgTF+5E5bmlmBoA0dDO33IkwaXM+9x02dMvsPue/g1C1+e5VtlMHHk6Y0TmUJWKE7mdcFwuEsoH+w2TOPInoKw=="
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/nomo-plugin-kit/-/nomo-plugin-kit-0.1.0.tgz",
+      "integrity": "sha512-KPuOuw9gCWaVtMcFWB4OmN+l9Evevw2+V4cxWd6eElUs/FzpQlTuhgTSbkqyaFxacrZ2iv2myAYefRgn9TNvpw=="
     },
     "node_modules/object-assign": {
       "version": "4.1.1",

--- a/demo-plugin/package.json
+++ b/demo-plugin/package.json
@@ -14,9 +14,9 @@
     "@types/react-dom": "18.2.4",
     "eslint": "8.41.0",
     "eslint-config-next": "13.4.3",
-    "ethersjs-nomo-plugins": "^0.0.2",
+    "ethersjs-nomo-plugins": "^0.1.1",
     "next": "13.4.3",
-    "nomo-plugin-kit": "^0.0.6",
+    "nomo-plugin-kit": "^0.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "5.0.4"

--- a/ethersjs-nomo-plugins/package-lock.json
+++ b/ethersjs-nomo-plugins/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ethersjs-nomo-plugins",
-  "version": "0.0.2",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ethersjs-nomo-plugins",
-      "version": "0.0.2",
+      "version": "0.1.1",
       "license": "ISC",
       "dependencies": {
         "@types/node": "^20.5.9",
@@ -14,7 +14,7 @@
         "typescript": "5.0.4"
       },
       "peerDependencies": {
-        "nomo-plugin-kit": "^0.0.5"
+        "nomo-plugin-kit": "^0.1.0"
       }
     },
     "node_modules/@ethersproject/abi": {
@@ -819,9 +819,9 @@
       "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
     },
     "node_modules/nomo-plugin-kit": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/nomo-plugin-kit/-/nomo-plugin-kit-0.0.5.tgz",
-      "integrity": "sha512-upbHjNWDySBkWg2IscRRDOvOrbPzLCQodfmJ/9/krQYPqJ1Ak+bVKwDv3ZXtnsHmM1vqrOaXnckPAzJhwmcTlA==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/nomo-plugin-kit/-/nomo-plugin-kit-0.1.0.tgz",
+      "integrity": "sha512-KPuOuw9gCWaVtMcFWB4OmN+l9Evevw2+V4cxWd6eElUs/FzpQlTuhgTSbkqyaFxacrZ2iv2myAYefRgn9TNvpw==",
       "peer": true
     },
     "node_modules/scrypt-js": {

--- a/ethersjs-nomo-plugins/package.json
+++ b/ethersjs-nomo-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethersjs-nomo-plugins",
-  "version": "0.0.2",
+  "version": "0.1.1",
   "description": "ethersjs-nomo-plugins for nomo",
   "main": "dist",
   "scripts": {
@@ -17,7 +17,7 @@
     "@types/node": "^20.5.9"
   },
   "peerDependencies": {
-    "nomo-plugin-kit": "^0.0.5"
+    "nomo-plugin-kit": "^0.1.0"
   },
   "keywords": [],
   "author": "dev2@nomo.app",

--- a/nomo-plugin-kit/package-lock.json
+++ b/nomo-plugin-kit/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nomo-plugin-kit",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nomo-plugin-kit",
-      "version": "0.0.6",
+      "version": "0.1.0",
       "license": "ISC",
       "devDependencies": {
         "typedoc": "^0.25.1",

--- a/nomo-plugin-kit/package.json
+++ b/nomo-plugin-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nomo-plugin-kit",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "Nomo-Plugin-Kit for the Nomo App",
   "main": "dist",
   "scripts": {


### PR DESCRIPTION
This is necessary because peer dependency are pretty much broken for versions like 0.0.X.
See https://michaelsoolee.com/npm-pre-1-caret-rules/ for more details.